### PR TITLE
Restore part of build workflow with pypi section

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,3 +133,67 @@ jobs:
         name: Upload artifacts
         with:
           path: dist/*.tar.gz
+
+  upload_pypi:
+    needs:
+      - "build_wheels"
+      - "build_sdist"
+
+    # It only needs to run once.  It will fetch all of the other build
+    # artifacts created by the other jobs and then upload them.
+    runs-on: "ubuntu-latest"
+
+    # Select the GitHub Actions environment that contains the PyPI tokens
+    # necessary to perform uploads.  This was configured manually using the
+    # GitHub web interface.
+    environment: "release"
+
+    steps:
+      # Download all artifacts previously built by this workflow to the dist
+      # directory where the publish step can find them.  These are the sdist
+      # and all of the wheels build by the other jobs.
+      - uses: "actions/download-artifact@v2"
+        with:
+          name: "artifact"
+          path: "dist"
+
+      # Define a conditional step to upload packages to the testing instance
+      # of PyPI.
+      #
+      # The overall workflow is already restricted so that it runs for:
+      # 1) pushes to master
+      # 2) pushes to release tags
+      # 3) pushes to branches with associated PRs
+      #
+      # The conditional in this step should cause it to run only for case (3).
+      - name: "Publish to TEST PyPI"
+        uses: "pypa/gh-action-pypi-publish@master"
+        if: >-
+          github.event_name == 'pull_request'
+
+        with:
+          # Authenticate using a token from a PyPI account with upload
+          # permission to the project.  See https://pypi.org/help/#apitoken
+          user: "__token__"
+          # Read it from a GitHub Actions "environment" secret.  See
+          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          password: "${{ secrets.testpypi_token }}"
+          # Override the default in order to upload it to the testing
+          # deployment.
+          repository_url: "https://test.pypi.org/legacy/"
+
+      # Now define a conditional step to upload packages to the production
+      # instance of PyPI.
+      #
+      # The cases to consider are the same as for the upload to the testing
+      # instance.  This time, we have a conditional that runs only for case
+      # (2).
+      - name: "Publish to LIVE PyPI"
+        uses: "pypa/gh-action-pypi-publish@master"
+        if: >-
+          github.event_name == 'push' &&
+          startsWith(github.event.ref, 'refs/tags/zfex-')
+
+        with:
+          user: "__token__"
+          password: "${{ secrets.pypi_token }}"


### PR DESCRIPTION
Also, add secrets:
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Resolves (#33)