### PR TITLE
Ignore error reported by `make clean`

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -5,4 +5,4 @@ bench_zfex: bench_zfex.c ../zfex/zfex.c ../zfex/zfex.h ../zfex/zfex_pp.h ../zfex
 	${CC} ${CFLAGS} -fno-strict-aliasing -Wall -Wextra -Werror -Wshadow -Wdate-time -Wformat -Werror=format-security -std=c99 -DZFEX_STRIDE=$(STRIDE) -DZFEX_UNROLL_ADDMUL=$(UNROLL) -o bench_zfex bench_zfex.c ../zfex/zfex.c  -I../zfex
 
 clean:
-	rm bench_zfex
+	- rm bench_zfex


### PR DESCRIPTION
When files to be removed do not exist make clean fails with error.

Resolves (#91)